### PR TITLE
Update What-is-Gas.md and What-is-Mining.md Regarding the ETH 2.0 or Eth2 misnomer and Post Merge edits.

### DIFF
--- a/What-is-Gas.md
+++ b/What-is-Gas.md
@@ -217,7 +217,7 @@ But, none of that matters if users have to keep spending hundreds of dollars to 
 
 As such, there are a lot of things being worked on, and some already available, to allow for a reduction in gas fees and improve the user experience.
 
-Primarily, the network upgrades that will be offered by Ethereum 2.0 (also known as Eth2) will ultimately address some of the gas issues, which in turn will enable the network to process thousands of transactions per second and scale globally.
+Primarily, the [network upgrades](https://ethereum.org/en/upgrades/) that will be offered by Ethereum will ultimately address some of the gas issues, which in turn will enable the network to process thousands of transactions per second and scale globally.
 
 In addition, a lot of work is being done on Layer 2 Scaling. We will learn much more in depth about Layer 2 Scaling and Layer 2 platforms later on, but essentially they are networks which shift the heavy computation aspects of smart contracts somewhere else, and use the Ethereum mainnet as a final settlement layer, thereby inheriting the security and decentralization benefits of Ethereum, and maintaining low gas fees and high transaction speed for users.
 

--- a/What-is-Mining.md
+++ b/What-is-Mining.md
@@ -2,9 +2,9 @@
 
 Mining is the process that helps create new blocks of transactions to be added to the Ethereum blockchain network. It also helps keep the network secure from attacks.
 
-Just like Bitcoin, Ethereum was using a Proof-of-Work (PoW) consensus mechanism, which is heavily reliant on mining. Ethereum miners use their time and computation power to process new incoming transactions and produce new blocks.
+Just like Bitcoin, Ethereum was using a Proof-of-Work (PoW) consensus mechanism, which is heavily reliant on mining. Ethereum miners used their time and computation power to process new incoming transactions and produce new blocks untill Ethereum upgraded to Proof-of-Stake consensus mechanism (PoS).
 
-> Ethereum Merge (The Merge was executed on September 15, 2022) it replaced Proof of Work with Proof of Stake, which significantly changed how new blocks are produced and reducing energy consumption by ~99.95%. We will talk about [The merge](https://ethereum.org/en/upgrades/merge/) later.
+> [Ethereum Merge](https://ethereum.org/en/upgrades/merge/) (The Merge was executed on September 15, 2022) it replaced Proof of Work with Proof of Stake, which significantly changed how new blocks are produced reducing energy consumption by ~99.95%. We will talk more about Proof-of-Stake later.
 
 <Quiz questionId="6ad2fd8e-0241-4c0a-a66e-2b01116e4a9d" />
 

--- a/What-is-Mining.md
+++ b/What-is-Mining.md
@@ -2,9 +2,9 @@
 
 Mining is the process that helps create new blocks of transactions to be added to the Ethereum blockchain network. It also helps keep the network secure from attacks.
 
-Just like Bitcoin, Ethereum was using a Proof-of-Work (PoW) consensus mechanism, which is heavily reliant on mining. Ethereum miners used their time and computation power to process new incoming transactions and produce new blocks untill Ethereum upgraded to Proof-of-Stake consensus mechanism (PoS).
+Just like Bitcoin, Ethereum was using a Proof-of-Work (PoW) consensus mechanism, which is heavily reliant on mining. Ethereum miners used their time and computation power to process new incoming transactions and produce new blocks until Ethereum upgraded to Proof-of-Stake consensus mechanism (PoS).
 
-> [Ethereum Merge](https://ethereum.org/en/upgrades/merge/) (The Merge was executed on September 15, 2022) it replaced Proof of Work with Proof of Stake, which significantly changed how new blocks are produced reducing energy consumption by ~99.95%. We will talk more about Proof-of-Stake later.
+> The [Ethereum Merge](https://ethereum.org/en/upgrades/merge/) which was executed on September 15, 2022, replaced Proof-of-Work with Proof-of-Stake. This significantly changed how new blocks are produced, [reducing energy consumption](https://ethereum.org/en/energy-consumption/) by ~99.95%. The topic Proof-of-Stake will be discussed in a later course.
 
 <Quiz questionId="6ad2fd8e-0241-4c0a-a66e-2b01116e4a9d" />
 

--- a/What-is-Mining.md
+++ b/What-is-Mining.md
@@ -2,9 +2,9 @@
 
 Mining is the process that helps create new blocks of transactions to be added to the Ethereum blockchain network. It also helps keep the network secure from attacks.
 
-Just like Bitcoin, Ethereum currently uses a Proof-of-Work (PoW) consensus mechanism, which is heavily reliant on mining. Ethereum miners use their time and computation power to process new incoming transactions and produce new blocks.
+Just like Bitcoin, Ethereum was using a Proof-of-Work (PoW) consensus mechanism, which is heavily reliant on mining. Ethereum miners use their time and computation power to process new incoming transactions and produce new blocks.
 
-> Ethereum 2.0 (scheduled for mid-late 2022) will replace Proof of Work with Proof of Stake, which will significantly change how new blocks are produced. We will talk about Eth2 later.
+> Ethereum Merge (The Merge was executed on September 15, 2022) it replaced Proof of Work with Proof of Stake, which significantly changed how new blocks are produced and reducing energy consumption by ~99.95%. We will talk about [The merge](https://ethereum.org/en/upgrades/merge/) later.
 
 <Quiz questionId="6ad2fd8e-0241-4c0a-a66e-2b01116e4a9d" />
 


### PR DESCRIPTION
As the roadmap for Ethereum has evolved, Ethereum 2.0 has become an inaccurate representation of Ethereum’s roadmap. It is also misrepresented by some as Etheruem after the merge.This is clarified in their [official blog](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming).