### PR TITLE
Update .env folder in Whitelist-dApp.md

### DIFF
--- a/Whitelist-dApp.md
+++ b/Whitelist-dApp.md
@@ -158,7 +158,7 @@ Now open the hardhat.config.js file, we would add the `goerli` network here so t
 
 ```js
 require("@nomicfoundation/hardhat-toolbox");
-require("dotenv").config({ path: ".env" });
+require("dotenv").config({ path: "hardhat-tutorial/.env" });
 
 const QUICKNODE_HTTP_URL = process.env.QUICKNODE_HTTP_URL;
 const PRIVATE_KEY = process.env.PRIVATE_KEY;


### PR DESCRIPTION
people were instructed to create the .env file in the hardhat-tutorial folder hence the .env file path should include that directory