### PR TITLE
flow / order of instructions

### DIFF
--- a/NFT-Collection.md
+++ b/NFT-Collection.md
@@ -804,12 +804,12 @@ export default function Home() {
 
 Now create a new folder under the `my-app` folder and name it `constants`. In the `constants` folder create a file, `index.js` and paste the following code.
 
-Replace `"addres of your NFT contract"` with the address of the CryptoDevs contract that you deployed and saved to your notepad. Replace `---your abi---` with the abi of your CryptoDevs Contract. To get the abi for your contract, go to your `hardhat-tutorial/artifacts/contracts/CryptoDevs.sol` folder and from your `CryptoDevs.json` file get the array marked under the `"abi"` key.
-
 ```js
-export const abi =---your abi---
 export const NFT_CONTRACT_ADDRESS = "address of your NFT contract"
+export const abi =---your abi---
 ```
+
+Replace `"addres of your NFT contract"` with the address of the CryptoDevs contract that you deployed and saved to your notepad. Replace `---your abi---` with the abi of your CryptoDevs Contract. To get the abi for your contract, go to your `hardhat-tutorial/artifacts/contracts/CryptoDevs.sol` folder and from your `CryptoDevs.json` file get the array marked under the `"abi"` key.
 
 Now in your terminal which is pointing to `my-app` folder, execute
 


### PR DESCRIPTION
moved the code to be immediately after the "paste the following code" instruction switched the order of the exports so they're the same as the instructions, and so the single line contract address comes before the bigger abi value which would push the former off the page / out of view