### PR TITLE
enable owner to withdraw via frontend & participate in mint

### DIFF
--- a/Initial-Coin-Offering.md
+++ b/Initial-Coin-Offering.md
@@ -807,7 +807,7 @@ export default function Home() {
               </div>
               {renderButton()}
               {/* Display additional withdraw button if connected wallet is owner */}
-                {walletConnected && isOwner ? (
+                {isOwner ? (
                   <div>
                   {loading ? <button className={styles.button}>Loading...</button>
                            : <button className={styles.button} onClick={withdrawCoins}>

--- a/Initial-Coin-Offering.md
+++ b/Initial-Coin-Offering.md
@@ -642,7 +642,7 @@ export default function Home() {
   };
 
   /**
-   * withdrawCoins: withdraws ether and tokens by calling
+   * withdrawCoins: withdraws ether by calling
    * the withdraw function in the contract
    */
   const withdrawCoins = async () => {
@@ -810,7 +810,7 @@ export default function Home() {
                 {walletConnected && isOwner ? (
                   <div>
                   {loading ? <button className={styles.button}>Loading...</button>
-                           : <button className={styles.button1} onClick={withdrawCoins}>
+                           : <button className={styles.button} onClick={withdrawCoins}>
                                Withdraw Coins
                              </button>
                   }

--- a/Initial-Coin-Offering.md
+++ b/Initial-Coin-Offering.md
@@ -173,13 +173,15 @@ Create another file inside the `contracts` directory and call it `CryptoDevToken
       }
 
       /**
-        * @dev withdraws all ETH and tokens sent to the contract
+        * @dev withdraws all ETH sent to this contract
         * Requirements:
         * wallet connected must be owner's address
         */
       function withdraw() public onlyOwner {
-        address _owner = owner();
         uint256 amount = address(this).balance;
+        require(amount > 0, "Nothing to withdraw; contract balance empty");
+        
+        address _owner = owner();
         (bool sent, ) = _owner.call{value: amount}("");
         require(sent, "Failed to send Ether");
       }
@@ -659,6 +661,7 @@ export default function Home() {
       await getOwner();
     } catch (err) {
       console.error(err);
+      window.alert(err.reason);
     }
   };
 
@@ -725,7 +728,7 @@ export default function Home() {
       getTotalTokensMinted();
       getBalanceOfCryptoDevTokens();
       getTokensToBeClaimed();
-      withdrawCoins();
+      getOwner();
     }
   }, [walletConnected]);
 
@@ -738,16 +741,6 @@ export default function Home() {
       return (
         <div>
           <button className={styles.button}>Loading...</button>
-        </div>
-      );
-    }
-    // if owner is connected, withdrawCoins() is called
-    if (walletConnected && isOwner) {
-      return (
-        <div>
-          <button className={styles.button1} onClick={withdrawCoins}>
-            Withdraw Coins
-          </button>
         </div>
       );
     }
@@ -813,6 +806,17 @@ export default function Home() {
                 Overall {utils.formatEther(tokensMinted)}/10000 have been minted!!!
               </div>
               {renderButton()}
+              {/* Display additional withdraw button if connected wallet is owner */}
+                {walletConnected && isOwner ? (
+                  <div>
+                  {loading ? <button className={styles.button}>Loading...</button>
+                           : <button className={styles.button1} onClick={withdrawCoins}>
+                               Withdraw Coins
+                             </button>
+                  }
+                  </div>
+                  ) : ("")
+                }
             </div>
           ) : (
             <button onClick={connectWallet} className={styles.button}>


### PR DESCRIPTION
adds a separate withdraw button so owner can withdraw and also participate in the claim/mint; CryptoDevToken.withdraw() returns an error if balance is 0, front-end withdrawCoins() catches & shows it to user. useEffect() when walletConnected now calls getOwner()