### PR TITLE
Update Whitelist-dApp.md

### DIFF
--- a/Whitelist-dApp.md
+++ b/Whitelist-dApp.md
@@ -49,6 +49,11 @@ cd hardhat-tutorial
 npm init --yes
 npm install --save-dev hardhat
 ```
+If you are a Windows User, you'll have to add one more dependency. It is given below:
+
+```bash 
+npm install --save-dev @nomicfoundation/hardhat-toolbox
+```
 
 In the same directory where you installed Hardhat run:
 


### PR DESCRIPTION
Windows users need to download one more dependency which is not mentioned on the website . Due to this , many learners were getting errors. 
I  added that part so that they won't get confused anymore
