### PR TITLE
Changing window.alert error messages

### DIFF
--- a/Decentralized-Autonomous-Organizations.md
+++ b/Decentralized-Autonomous-Organizations.md
@@ -792,7 +792,7 @@ export default function Home() {
       setLoading(false);
     } catch (error) {
       console.error(error);
-      window.alert(error.data.message);
+      window.alert(error.reason);
     }
   };
 
@@ -849,7 +849,7 @@ export default function Home() {
       await fetchAllProposals();
     } catch (error) {
       console.error(error);
-      window.alert(error.data.message);
+      window.alert(error.reason);
     }
   };
 
@@ -867,7 +867,7 @@ export default function Home() {
       getDAOTreasuryBalance();
     } catch (error) {
       console.error(error);
-      window.alert(error.data.message);
+      window.alert(error.reason);
     }
   };
 


### PR DESCRIPTION
When it came to functions such as 
```js
 const createProposal = async () => {
    try {
      const signer = await getProviderOrSigner(true);
      const daoContract = getDaoContractInstance(signer);
      const txn = await daoContract.createProposal(fakeNftTokenId);
      setLoading(true);
      await txn.wait();
      await getNumProposalsInDAO();
      setLoading(false);
    } catch (error) {
      console.error(error);
      window.alert(error.data.message);
    }
  };
```
When a smart contract revert is thrown, Next.js would instead throw an error and would point to the error in this piece of code:
```js
 } catch (error) {
      console.error(error);
      window.alert(error.data.message);
    }
```
Particularly, it would say that `error.data.message` is not defined. Sometimes this works and sometimes it doesn't. So instead of doing `error.data.message`, I instead changed it to `error.reason` and the alert will either pop up the correct error message from the smart contract or it will say `undefined`.

This was inspired by @manisha6700 