### PR TITLE
Add npm install, sometimes needs hardhat tool

### DIFF
--- a/Initial-Coin-Offering.md
+++ b/Initial-Coin-Offering.md
@@ -295,7 +295,7 @@ module.exports = {
 };
 ```
 
-Before compiling our smart contract, we may need to install the Hardhat tools, "npm install --save-dev @nomicfoundation/hardhat-toolbox" is a command used to install a package called "hardhat-toolbox" from the "@nomicfoundation" organization as a development dependency in a Node.js project. This package provides a set of utilities and plugins for the Hardhat Ethereum development environment, which is a tool that allows developers to easily test and deploy smart contracts on a local Ethereum network. The "--save-dev" flag indicates that this package is intended to be used for development purposes only, and will not be needed in production.
+This package provides a set of utilities and plugins for the Hardhat Ethereum development environment, which is a tool that allows developers to easily test and deploy smart contracts on a local Ethereum network. The "--save-dev" flag indicates that this package is intended to be used for development purposes only, and will not be needed in production.
 ```bash
 npm install --save-dev @nomicfoundation/hardhat-toolbox
 ```

--- a/Initial-Coin-Offering.md
+++ b/Initial-Coin-Offering.md
@@ -295,6 +295,12 @@ module.exports = {
 };
 ```
 
+Before compiling our smart contract, we may need to install the Hardhat tools, "npm install --save-dev @nomicfoundation/hardhat-toolbox" is a command used to install a package called "hardhat-toolbox" from the "@nomicfoundation" organization as a development dependency in a Node.js project. This package provides a set of utilities and plugins for the Hardhat Ethereum development environment, which is a tool that allows developers to easily test and deploy smart contracts on a local Ethereum network. The "--save-dev" flag indicates that this package is intended to be used for development purposes only, and will not be needed in production.
+```bash
+npm install --save-dev @nomicfoundation/hardhat-toolbox
+```
+
+
 Compile the contract, open up a terminal pointing to the `hardhat-tutorial` directory and execute this command:
 
 ```bash


### PR DESCRIPTION
Before compiling our smart contract, we may need to install the Hardhat tools, "npm install --save-dev @nomicfoundation/hardhat-toolbox" is a command used to install a package called "hardhat-toolbox" from the "@NomicFoundation" organization as a development dependency in a Node.js project. This package provides a set of utilities and plugins for the Hardhat Ethereum development environment, which is a tool that allows developers to easily test and deploy smart contracts on a local Ethereum network. The "--save-dev" flag indicates that this package is intended to be used for development purposes only, and will not be needed in production.