### PR TITLE
Update LW3Tokens/ETH swap example

### DIFF
--- a/DeFi-Exchange-Theory.md
+++ b/DeFi-Exchange-Theory.md
@@ -160,7 +160,7 @@ Assume we have `100 ETH` and `200 LW3 Token` in the contract.
 `inputReserve` = 200 LW3 Tokens
 `outputReserve` = 100 ETH
 
-=> `outputAmount` = `0.999` `ETH`
+=> `outputAmount` = `0.9901` `ETH`
 
 These amounts are very close to the `1:2` ratio of tokens present in the contract reserves, but slightly smaller. Why?
 


### PR DESCRIPTION
**What would happen if instead I wanted to swap 2 `LW3 Tokens` for ETH?** `inputAmount` = 2 LW3 Tokens
`inputReserve` = 200 LW3 Tokens
`outputReserve` = 100 ETH

So `outputAmount` should be =(100*2)/(200+2)=200/202 ~0.99009901 ~ 0.9901 ETH but in current version it shows 0.999ETH